### PR TITLE
Update procfile to run with latest joodo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: lein run -m joodo.main production -a 0.0.0.0 -p $PORT
+web: lein run -m joodo.main -e production -a 0.0.0.0 -p $PORT


### PR DESCRIPTION
See https://github.com/slagyr/joodo/issues/19

When running `foreman start` locally, I had a failure like this:

Exception in thread "main" java.lang.IllegalArgumentException: No value supplied for key: 5000

This patch to the Procfile works for me locally.
