### PR TITLE
Run specs w/ lein2 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
-script: lein spec
+script: lein2 spec
 lein: lein2


### PR DESCRIPTION
Not sure why `lein: lein2` doesn't alias `lein` everywhere, but that appears to be the case.
