### PR TITLE
Fix usage_docs.clj to accurately reflect usage of "env/load-configuratio...

### DIFF
--- a/src/joodoweb/docs/usage_docs.clj
+++ b/src/joodoweb/docs/usage_docs.clj
@@ -24,7 +24,7 @@
     :load-config?
     "(load-config? path-to-config)"
     :load-configurations
-    "(load-configurations path-to-config)"
+    "(load-configurations)"
     :load-configurations-unchecked
     "(load-config-unchecked path-to-config)"
 	}


### PR DESCRIPTION
...ns".

It was listed as taking a "path-to-config" parameter, but according to the source it doesn't take one.
